### PR TITLE
implementação de restrição para o sonarqube

### DIFF
--- a/genericparser/plugins/statics/sonarqube.py
+++ b/genericparser/plugins/statics/sonarqube.py
@@ -9,12 +9,13 @@ class ParserSonarQube(GenericStaticABC):
         for entry in input_file:
             key = entry.get("key", {})
             measures = entry.get("measures", [])
-            for measure in measures:
-                metric = measure.get("metric", None)
-                value = measure.get("value", None)
-                metrics.append(metric)
-                keys.append(key)
-                values.append(value)
+            if entry.get("qualifier") in ["FIL", "UTS", "TRK"]:
+                for measure in measures:
+                    metric = measure.get("metric", None)
+                    value = measure.get("value", None)
+                    metrics.append(metric)
+                    keys.append(key)
+                    values.append(value)
         return {"file_paths": keys, "metrics": metrics, "values": values}
 
 


### PR DESCRIPTION
Realizado implementação para restringir de colher as métricas do sonarqube somente se o qualifier for FIL,TRK ou UTS.